### PR TITLE
Add FSM per search item

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/anacrolix/mmsg v1.0.0 // indirect
 	github.com/anacrolix/torrent v1.1.4
 	github.com/cavaliercoder/grab v2.0.0+incompatible
+	github.com/dyrkin/fsm v0.0.0-20181122213812-68a0d0ca4628
 	github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 // indirect
 	github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible
 	github.com/google/btree v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20180421182945-02af3965c54e/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dyrkin/fsm v0.0.0-20181122213812-68a0d0ca4628 h1:K3sw2IzspoaCOYjTNXcpiYtwQnCeEN9PA5jhWDy0zq4=
+github.com/dyrkin/fsm v0.0.0-20181122213812-68a0d0ca4628/go.mod h1:C+ACovlJ2843kzxjLkE0HMZyxB6OG39JkmCb43M339g=
 github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
@@ -114,16 +116,8 @@ github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK86
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae h1:VeRdUYdCw49yizlSbMEn2SZ+gT+3IUKx8BqxyQdz+BY=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE+eKJXWVjKXM4ck2QobLqTDytGJbLLhJg=
-github.com/nenad/rd v0.0.10 h1:5hJyxRaOaHAJQWU3VmpVsurZOT4HB4jw35qaQVqw8iw=
-github.com/nenad/rd v0.0.10 h1:KMoNJWDqBGYnjJm1lcLqqf/TZvtMAVV4sfaNq0LKpGc=
-github.com/nenad/rd v0.0.10/go.mod h1:1AzVI2/KkrkXCaFhQJxyXJ8539+oycZVGdRp6Oseh9k=
-github.com/nenad/rd v0.0.10/go.mod h1:h3rE5en05BVVPYCVpS3nWuRpV/UthfDgv6PXYnaQW4I=
 github.com/nenad/rd v0.0.11 h1:QNE5bNrkGVMaGVCqWmsgviDNYj3VT4vcc4h09P3JUg8=
 github.com/nenad/rd v0.0.11/go.mod h1:1AzVI2/KkrkXCaFhQJxyXJ8539+oycZVGdRp6Oseh9k=
-github.com/nenad/trakt v0.0.0-20190204225050-846f0c75551e h1:DxUtATn9S7NEaVNuMLdEO5ss25y/fG7YO0bg2tpg0c4=
-github.com/nenad/trakt v0.0.0-20190204225050-846f0c75551e h1:bOmQVPBPNUeS8vNzhH3MAeUA02RxgAsRhq/qW6tcwpc=
-github.com/nenad/trakt v0.0.0-20190204225050-846f0c75551e/go.mod h1:XengqT3ziXCick8/LdzlRbzhNJu7g3z+p1gL2HToDnI=
-github.com/nenad/trakt v0.0.0-20190204225050-846f0c75551e/go.mod h1:qVj3qgElX8NntWRJVn1RCa66fI1MOJAm6KHWvddj398=
 github.com/nenad/trakt v0.0.0-20190615101746-fe85e7def576 h1:wkw2C2M/8YZSscNdMMdXKaiII/4rystwZ4QakBJqWkQ=
 github.com/nenad/trakt v0.0.0-20190615101746-fe85e7def576/go.mod h1:+zW4hy3fkQsRnBnI+VdS8EdNVb6oAvMlbCTT8LYh1Gk=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=

--- a/pkg/state/flow.go
+++ b/pkg/state/flow.go
@@ -1,0 +1,182 @@
+package state
+
+import (
+	"github.com/dyrkin/fsm"
+	"github.com/nenad/couch/pkg/media"
+	"github.com/nenad/couch/pkg/storage"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	PendingState          = fsm.State("Pending")
+	ScrapingState         = fsm.State("Scraping")
+	ScrapingErrorState    = fsm.State("ScrapingError")
+	ExtractingState       = fsm.State("Extracting")
+	ExtractingErrorState  = fsm.State("ExtractingError")
+	DownloadingState      = fsm.State("Downloading")
+	DownloadingErrorState = fsm.State("DownloadingError")
+	DownloadedState       = fsm.State("Downloaded")
+)
+
+type Flow struct {
+	item         media.SearchItem
+	scrapeFunc   func(item media.SearchItem) ScrapeResult
+	extractFunc  func([]storage.Magnet) ExtractResult
+	downloadFunc func([]storage.Download) DownloadResult
+
+	fsm          *fsm.FSM
+	scrapeDone   chan ScrapeResult
+	extractDone  chan ExtractResult
+	downloadDone chan DownloadResult
+}
+
+func (f *Flow) SetScrapeFunc(scraper func(item media.SearchItem) ScrapeResult) {
+	f.scrapeFunc = scraper
+}
+
+func (f *Flow) SetExtractFunc(extractor func(magnets []storage.Magnet) ExtractResult) {
+	f.extractFunc = extractor
+}
+
+func (f *Flow) SetDownloadFunc(downloader func(downloads []storage.Download) DownloadResult) {
+	f.downloadFunc = downloader
+}
+
+func (f *Flow) Begin() {
+	// Two updates, since we need to quickly switch two states: None->Pending->Scraping
+	f.update()
+	f.update()
+}
+
+func (f *Flow) Status() fsm.State {
+	return f.fsm.CurrentState()
+}
+
+func New(item media.SearchItem) *Flow {
+	f := fsm.NewFSM()
+
+	flow := &Flow{
+		item: item,
+
+		fsm:          f,
+		scrapeDone:   make(chan ScrapeResult, 1),
+		extractDone:  make(chan ExtractResult, 1),
+		downloadDone: make(chan DownloadResult, 1),
+		scrapeFunc: func(item media.SearchItem) ScrapeResult {
+			return ScrapeResult{}
+		},
+		extractFunc: func(magnets []storage.Magnet) ExtractResult {
+			return ExtractResult{}
+		},
+		downloadFunc: func(downloads []storage.Download) DownloadResult {
+			return DownloadResult{}
+		},
+	}
+
+	f.OnTransition(func(from fsm.State, to fsm.State) {
+		logrus.Debugf("%s: Moving from %q to %q", item.Term, from, to)
+	})
+
+	f.SetDefaultHandler(func(event *fsm.Event) *fsm.NextState {
+		logrus.Errorf("Could not handle event: %#v", event)
+		return f.Stay()
+	})
+
+	f.StartWith(PendingState, item)
+
+	f.When(PendingState)(func(event *fsm.Event) *fsm.NextState {
+		return f.Goto(ScrapingState).With(event.Data)
+	})
+
+	f.When(ScrapingState)(func(event *fsm.Event) *fsm.NextState {
+		item := event.Data.(media.SearchItem)
+
+		result := flow.scrapeFunc(item)
+		flow.scrapeDone <- result
+
+		if result.Error != nil {
+			return f.Goto(ScrapingErrorState).With(result.Error)
+		}
+
+		return f.Goto(ExtractingState).With(result.Value)
+	})
+
+	f.When(ExtractingState)(func(event *fsm.Event) *fsm.NextState {
+		magnets := event.Data.([]storage.Magnet)
+
+		result := flow.extractFunc(magnets)
+		flow.extractDone <- result
+
+		if result.Error != nil {
+			return f.Goto(ExtractingErrorState).With(result.Error)
+		}
+
+		return f.Goto(DownloadingState).With(result.Value)
+	})
+
+	f.When(DownloadingState)(func(event *fsm.Event) *fsm.NextState {
+		item := event.Data.([]storage.Download)
+
+		result := flow.downloadFunc(item)
+		flow.downloadDone <- result
+
+		if result.Error != nil {
+			return f.Goto(DownloadingErrorState).With(result.Error)
+		}
+
+		return f.Goto(DownloadedState)
+	})
+
+	f.When(DownloadedState)(func(event *fsm.Event) *fsm.NextState {
+		i := event.Message.(media.SearchItem)
+		close(flow.scrapeDone)
+		close(flow.extractDone)
+		close(flow.downloadDone)
+		logrus.Infof("Downloaded %q successfully", i.Term)
+		return f.Stay()
+	})
+
+	f.When(ScrapingErrorState)(func(event *fsm.Event) *fsm.NextState {
+		logrus.Errorf("Scraping failed: %#v", event.Data)
+		return f.Stay()
+	})
+	f.When(ExtractingErrorState)(func(event *fsm.Event) *fsm.NextState {
+		logrus.Errorf("Extracting failed: %#v", event.Data)
+		return f.Stay()
+	})
+	f.When(DownloadingErrorState)(func(event *fsm.Event) *fsm.NextState {
+		logrus.Errorf("Downloading failed: %#v", event.Data)
+		return f.Stay()
+	})
+
+	// Set up listeners for state changes
+	go func() {
+	outer:
+		for {
+			select {
+			case r := <-flow.scrapeDone:
+				if r.Error != nil {
+					flow.fsm.Goto(ScrapingErrorState) // TODO Retry after timeout
+				}
+				flow.update()
+			case r := <-flow.extractDone:
+				if r.Error != nil {
+					flow.fsm.Goto(ExtractingErrorState) // TODO Retry after timeout
+				}
+				flow.update()
+			case r := <-flow.downloadDone:
+				if r.Error != nil {
+					flow.fsm.Goto(DownloadingErrorState) // TODO Retry after timeout
+				}
+				flow.update()
+				break outer
+			}
+		}
+	}()
+
+	return flow
+}
+
+func (f *Flow) update() {
+	f.fsm.Send(f.item)
+}

--- a/pkg/state/flow_test.go
+++ b/pkg/state/flow_test.go
@@ -1,0 +1,70 @@
+package state_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nenad/couch/pkg/media"
+	"github.com/nenad/couch/pkg/state"
+	"github.com/nenad/couch/pkg/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlow_DefaultStateIsPending(t *testing.T) {
+	item := media.NewMovie("Batman", 2010, "tBadman")
+	f := state.New(item)
+	assert.Equal(t, state.PendingState, f.Status())
+}
+
+func TestFlow_BeginFinishesWithDownloadedAfterDelay(t *testing.T) {
+	item := media.NewMovie("Batman", 2010, "tBadman")
+	f := state.New(item)
+	f.Begin()
+	time.Sleep(time.Millisecond * 50)
+	assert.Equal(t, state.DownloadedState, f.Status())
+}
+
+func TestFlow_SetScrapeFunc(t *testing.T) {
+	item := media.NewMovie("Batman", 2010, "tBadman")
+	f := state.New(item)
+
+	executed := false
+
+	f.SetScrapeFunc(func(item media.SearchItem) state.ScrapeResult {
+		executed = true
+		return state.ScrapeResult{}
+	})
+	f.Begin()
+	time.Sleep(time.Millisecond * 50)
+	assert.True(t, executed)
+}
+
+func TestFlow_SetExtractFunc(t *testing.T) {
+	item := media.NewMovie("Batman", 2010, "tBadman")
+	f := state.New(item)
+
+	executed := false
+
+	f.SetExtractFunc(func(magnets []storage.Magnet) state.ExtractResult {
+		executed = true
+		return state.ExtractResult{}
+	})
+	f.Begin()
+	time.Sleep(time.Millisecond * 50)
+	assert.True(t, executed)
+}
+
+func TestFlow_SetDownloadFunc(t *testing.T) {
+	item := media.NewMovie("Batman", 2010, "tBadman")
+	f := state.New(item)
+
+	executed := false
+
+	f.SetDownloadFunc(func(downloads []storage.Download) state.DownloadResult {
+		executed = true
+		return state.DownloadResult{}
+	})
+	f.Begin()
+	time.Sleep(time.Millisecond * 50)
+	assert.True(t, executed)
+}


### PR DESCRIPTION
Each search item can manage it's own state now, and we'll get rid of the centralized pipeline that doesn't offer much flexibility.